### PR TITLE
update 'add keep-before-data option'

### DIFF
--- a/src/extract_data_dai/__init__.py
+++ b/src/extract_data_dai/__init__.py
@@ -32,6 +32,7 @@ def run(
     end_date: I.str("结束日期/end_date，示例 2023-01-01") = "2020-12-31",
     end_date_bound_to_trading_date: I.bool("结束日期绑定交易日，在模拟和实盘交易模式下，结束日期替换为交易日") = False,
     before_start_days: I.int("历史数据向前取的天数，实际开始日期会减去此天数，用于计算需要向前历史数据的因子，比如 m_lag(close, 10)，需要向前去10天数据") = 90,
+    keep_before: I.bool("保留向前所取天数的数据(使用时请注意在前置'输入特征'模块中不要勾选[表达式--移除空值])") = False,
     debug: I.bool("调试模式，显示调试日志") = False,
 ) -> [I.port("数据", "data")]:
     """DAI 数据抽取模块。根据给定的DAI SQL，抽取数据。"""
@@ -75,6 +76,8 @@ def run(
     except:
         pass
     data = dai.query(sql, filters={"date": [query_start_date, end_date]}).df()
+    if keep_before :
+        start_date = query_start_date
     if "date" in data.columns:
         data = data[(data["date"] >= start_date) & (data["date"] <= end_date)]
     logger.info(f"data extracted: {data.shape}")

--- a/src/extract_data_dai/__init__.py
+++ b/src/extract_data_dai/__init__.py
@@ -76,7 +76,7 @@ def run(
     except:
         pass
     data = dai.query(sql, filters={"date": [query_start_date, end_date]}).df()
-    if keep_before :
+    if keep_before:
         start_date = query_start_date
     if "date" in data.columns:
         data = data[(data["date"] >= start_date) & (data["date"] <= end_date)]


### PR DESCRIPTION
This pull request includes changes to the `src/extract_data_dai/__init__.py` file to add a new parameter and modify the data extraction logic. The most important changes include adding a new boolean parameter `keep_before` and updating the data filtering logic to account for this parameter.

Enhancements to data extraction:

* [`src/extract_data_dai/__init__.py`](diffhunk://#diff-6ca3f7d358bebf94a0dd22a47e35b874a692c57f5424c5e6487b9ea83622cdfdR35): Added a new boolean parameter `keep_before` to the `run` function to allow users to retain the data from before the start date.
* [`src/extract_data_dai/__init__.py`](diffhunk://#diff-6ca3f7d358bebf94a0dd22a47e35b874a692c57f5424c5e6487b9ea83622cdfdR79-R80): Modified the data filtering logic to use `query_start_date` as the `start_date` if `keep_before` is set to `True`.